### PR TITLE
Changed default interpreteter to /bin/bash

### DIFF
--- a/ps-prechecks
+++ b/ps-prechecks
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This program is a derivative of pt-mysql-summary, which is a part 
 # of Percona Toolkit: http://www.percona.com/software/


### PR DESCRIPTION
Fixes "Syntax error: redirection unexpected" error when executing the script.

Happened on Ubuntu 18.04.6 LTS running 5.4.0-1089-aws Linux kernel