### PR TITLE
Add table_schema information to table size query

### DIFF
--- a/ps-prechecks
+++ b/ps-prechecks
@@ -923,7 +923,7 @@ find_my_cnf_file() {
 collect_table_sizes () {
    local total="$($CMD_MYSQL $EXT_ARGV -ss -e "SELECT SUM(data_length+index_length) AS size FROM information_schema.tables WHERE table_schema NOT IN ('information_schema','mysql','performance_schema','sys','_vt');" 2>/dev/null)"
    echo "Total    $total"   
-   $CMD_MYSQL $EXT_ARGV -ss -e "SELECT table_name, SUM(data_length+index_length) AS total_length, CONCAT(' (',SUM(table_rows),' rows)') AS table_rows_txt FROM information_schema.tables WHERE table_schema NOT IN ('information_schema','mysql','performance_schema','sys','_vt') GROUP BY table_name ORDER BY total_length DESC, sum(table_rows) DESC, table_name ASC;" 2>/dev/null
+   $CMD_MYSQL $EXT_ARGV -ss -e "SELECT CONCAT(table_schema,'.',table_name), SUM(data_length+index_length) AS total_length, CONCAT(' (',SUM(table_rows),' rows)') AS table_rows_txt FROM information_schema.tables WHERE table_schema NOT IN ('information_schema','mysql','performance_schema','sys','_vt') GROUP BY table_schema, table_name ORDER BY total_length DESC, sum(table_rows) DESC, table_name ASC;" 2>/dev/null
 }
 
 collect_mysql_variables () {


### PR DESCRIPTION
This PR fixes a bug where multiple tables of the same name in different schemas were summed up together rather than being listed separately.

Example with a table named `foo` in two schemas:

Previous output:
```
## Table Information (top 20, approx. row counts)
                              Total | 20G
...
                                foo | 32k (31 rows)
                                bar | 16k (8 rows)
```

New output:
```
## Table Information (top 20, approx. row counts)
                              Total | 20G
...
                          jonah.foo | 16k (30 rows)
                          jonah.bar | 16k (8 rows)
                       whatever.foo | 16k (1 rows)
```