### PR TITLE
Fix the regex for the --version flag

### DIFF
--- a/ps-prechecks
+++ b/ps-prechecks
@@ -96,7 +96,7 @@ usage_or_errors() {
    local version=""
 
    if [ "$OPT_VERSION" ]; then
-      version=$(grep '^pt-[^ ]\+ [0-9]' "$file")
+      version=$(grep '^ps-[^ ]\+ [0-9]' "$file")
       echo "$version"
       return 1
    fi


### PR DESCRIPTION
The version now starts with a `ps-` prefix.

https://github.com/planetscale/ps-prechecks/blob/ba38b94679c33e189c46dd23eb20bf1f1b5c781b/ps-prechecks#L2548