### PR TITLE
Swap table name and table size in markdown output

### DIFF
--- a/ps-prechecks
+++ b/ps-prechecks
@@ -1209,7 +1209,7 @@ format_table_sizes () {
    local counter=0
    while read var && [ $counter -lt 21 ]; do
       read -ra arr -d '' <<<"$var"
-      name_val "${arr[0]}" "$(shorten ${arr[1]} 0) ${arr[*]:2}"
+      name_val "$(shorten ${arr[1]} 0) ${arr[*]:2}" "${arr[0]}"
       let counter=counter+1
    done < "$file"
    


### PR DESCRIPTION
This PR fixes an issue with formatting of the Table Information section when the table name is very long. It does this by swapping the table name and the size fields, as the size field is consistently under the 35 character (minus 4 to account for the code block we get by starting out a line with 4 spaces) limit for the formatting in the `name_val` function.

It's not ideal, in that all other sections going to `name_val` have the name and then the value, and this is swapped, but I think it's the best way to make something legible in both raw output and markdown output.

# Here's an example where this was broken:

# Before:

## Table Information (top 20, approx. row counts)
                              Total | 22G
jonah_long_schema_name_here.long_table_name_like_sbtest1_but_longer | 2G (9134529 rows)
                   sysbench.sbtest1 | 2G (9864216 rows)
                   sysbench.sbtest5 | 2G (9864216 rows)
                   sysbench.sbtest7 | 2G (9612909 rows)
                  sysbench.sbtest10 | 2G (9868159 rows)
                   sysbench.sbtest4 | 2G (9624725 rows)
                   sysbench.sbtest9 | 2G (9869634 rows)
                   sysbench.sbtest8 | 2G (9870693 rows)
                   sysbench.sbtest3 | 2G (9871080 rows)
                   sysbench.sbtest6 | 2G (9871520 rows)
                   sysbench.sbtest2 | 2G (9871630 rows)
                      sakila.rental | 3M (16419 rows)
                     sakila.payment | 2M (16500 rows)
                   sakila.inventory | 368k (4581 rows)
                  sakila.film_actor | 272k (5462 rows)
                        sakila.film | 272k (1000 rows)
                   sakila.film_text | 192k (1000 rows)
                    sakila.customer | 128k (599 rows)
                     sakila.address | 112k (603 rows)
                       sakila.staff | 96k (2 rows)
# After:

## Table Information (top 20, approx. row counts)
                               22G  | Total
                  2G (9134529 rows) | jonah_long_schema_name_here.long_table_name_like_sbtest1_but_longer
                  2G (9864216 rows) | sysbench.sbtest1
                  2G (9864216 rows) | sysbench.sbtest5
                  2G (9612909 rows) | sysbench.sbtest7
                  2G (9868159 rows) | sysbench.sbtest10
                  2G (9624725 rows) | sysbench.sbtest4
                  2G (9869634 rows) | sysbench.sbtest9
                  2G (9870693 rows) | sysbench.sbtest8
                  2G (9871080 rows) | sysbench.sbtest3
                  2G (9871520 rows) | sysbench.sbtest6
                  2G (9871630 rows) | sysbench.sbtest2
                    3M (16419 rows) | sakila.rental
                    2M (16500 rows) | sakila.payment
                   368k (4581 rows) | sakila.inventory
                   272k (5462 rows) | sakila.film_actor
                   272k (1000 rows) | sakila.film
                   192k (1000 rows) | sakila.film_text
                    128k (599 rows) | sakila.customer
                    112k (603 rows) | sakila.address
                       96k (2 rows) | sakila.staff


# Here's an example where this was _not_ broken:

# Before:

## Table Information (top 20, approx. row counts)
                              Total | 22G
                   sysbench.sbtest1 | 2G (9864216 rows)
                   sysbench.sbtest5 | 2G (9864216 rows)
                   sysbench.sbtest7 | 2G (9612909 rows)
                  sysbench.sbtest10 | 2G (9868159 rows)
                   sysbench.sbtest4 | 2G (9624725 rows)
                   sysbench.sbtest9 | 2G (9869634 rows)
                   sysbench.sbtest8 | 2G (9870693 rows)
                   sysbench.sbtest3 | 2G (9871080 rows)
                   sysbench.sbtest6 | 2G (9871520 rows)
                   sysbench.sbtest2 | 2G (9871630 rows)
                      sakila.rental | 3M (16419 rows)
                     sakila.payment | 2M (16500 rows)
                   sakila.inventory | 368k (4581 rows)
                  sakila.film_actor | 272k (5462 rows)
                        sakila.film | 272k (1000 rows)
                   sakila.film_text | 192k (1000 rows)
                    sakila.customer | 128k (599 rows)
                     sakila.address | 112k (603 rows)
                       sakila.staff | 96k (2 rows)
# After:

## Table Information (top 20, approx. row counts)
                               22G  | Total
                  2G (9864216 rows) | sysbench.sbtest1
                  2G (9864216 rows) | sysbench.sbtest5
                  2G (9612909 rows) | sysbench.sbtest7
                  2G (9868159 rows) | sysbench.sbtest10
                  2G (9624725 rows) | sysbench.sbtest4
                  2G (9869634 rows) | sysbench.sbtest9
                  2G (9870693 rows) | sysbench.sbtest8
                  2G (9871080 rows) | sysbench.sbtest3
                  2G (9871520 rows) | sysbench.sbtest6
                  2G (9871630 rows) | sysbench.sbtest2
                    3M (16419 rows) | sakila.rental
                    2M (16500 rows) | sakila.payment
                   368k (4581 rows) | sakila.inventory
                   272k (5462 rows) | sakila.film_actor
                   272k (1000 rows) | sakila.film
                   192k (1000 rows) | sakila.film_text
                    128k (599 rows) | sakila.customer
                    112k (603 rows) | sakila.address
                       96k (2 rows) | sakila.staff

