### PR TITLE
Allow ps-prechecks to create tarball even if freeform_questions.md is missing

### DIFF
--- a/ps-prechecks
+++ b/ps-prechecks
@@ -1913,7 +1913,9 @@ report_mysql_summary () {
    section "The End" | tee -a $OUTFILE
    echo "" | tee -a $OUTFILE
 
-   tar -czf ps_archive_$TIMESTAMP.tgz $OUTFILE $SAMPLES_DIR *questions*.md
+   FREEFORM_RESPONSES=`ls *questions*.md`
+
+   tar -czf ps_archive_$TIMESTAMP.tgz $OUTFILE $SAMPLES_DIR $FREEFORM_RESPONSES
 }
 
 # ###########################################################################


### PR DESCRIPTION
This PR fixes a bug where if you move the ps-prechecks script elsewhere, without the freeform_questions.md file, the tar command fails. Now we include the `freeform_questions.md` if it is there, and otherwise pass an empty string.